### PR TITLE
[#2] 사용자(user) 엔티티 생성

### DIFF
--- a/src/main/java/com/prgrms/bdbks/domain/user/authority/Authority.java
+++ b/src/main/java/com/prgrms/bdbks/domain/user/authority/Authority.java
@@ -1,0 +1,5 @@
+package com.prgrms.bdbks.domain.user.authority;
+
+public enum Authority {
+	USER, ADMIN
+}

--- a/src/main/java/com/prgrms/bdbks/domain/user/entity/User.java
+++ b/src/main/java/com/prgrms/bdbks/domain/user/entity/User.java
@@ -1,0 +1,78 @@
+package com.prgrms.bdbks.domain.user.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.prgrms.bdbks.common.domain.TimeAndByColumn;
+import com.prgrms.bdbks.domain.user.authority.Authority;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends TimeAndByColumn {
+
+	@Id
+	@Column(name = "user_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Size(min = 6, max = 20)
+	@Column(name = "login_id", nullable = false, unique = true)
+	private String loginId;
+
+	@Size(min = 8, max = 20)
+	@Column(nullable = false)
+	@JsonIgnore
+	private String password;
+
+	@Size(min = 4, max = 20)
+	@Column(nullable = false)
+	private String nickName;
+
+	@Temporal(TemporalType.DATE)
+	@Column(nullable = false)
+	private LocalDateTime birthDate;
+
+	@Size(min = 11, max = 11)
+	@Column(nullable = false, unique = true)
+	private String phone;
+
+	@Email
+	@Column(nullable = false, unique = true)
+	private String email;
+
+	@Enumerated(EnumType.STRING)
+	private Authority authority;
+
+	@Builder
+	public User(Long id, String loginId, String password, String nickName, LocalDateTime birthDate, String phone,
+		String email, Authority authority) {
+		this.id = id;
+		this.loginId = loginId;
+		this.password = password;
+		this.nickName = nickName;
+		this.birthDate = birthDate;
+		this.phone = phone;
+		this.email = email;
+		this.authority = authority;
+	}
+}

--- a/src/main/java/com/prgrms/bdbks/domain/user/entity/User.java
+++ b/src/main/java/com/prgrms/bdbks/domain/user/entity/User.java
@@ -10,13 +10,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.prgrms.bdbks.common.domain.TimeAndByColumn;
+import com.prgrms.bdbks.common.domain.AbstractTimeColumn;
 import com.prgrms.bdbks.domain.user.authority.Authority;
 
 import lombok.AccessLevel;
@@ -28,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends TimeAndByColumn {
+public class User extends AbstractTimeColumn {
 
 	@Id
 	@Column(name = "user_id")
@@ -48,7 +46,6 @@ public class User extends TimeAndByColumn {
 	@Column(nullable = false)
 	private String nickName;
 
-	@Temporal(TemporalType.DATE)
 	@Column(nullable = false)
 	private LocalDateTime birthDate;
 


### PR DESCRIPTION
User Entity를 생성하고 기본적으로 필요한 필드들을 추가

### 🍀 목적
- User Entity 생성

### 🌹 추가사항
- User Entity와 Authority Enum을 생성했습니다.
- Authority는 USER, ADMIN으로 구성했습니다.

### ❓ pr 포인트
- guava를 사용한 검증로직과 테스트 코드는 곧 추가하겠습니다.
- @Size를 이용해 몇몇 컬럼의 길이를 제한했는데, 길이 관련해서 변경해야 할 부분이나 추가해야 할 부분 말씀해주시면 수정하겠습니다.

### 📢 Help
- Authority(권한)을 시큐리티 도입 전까지 `Enum`으로 관리하기로 하였습니다. 따라서 일단 패키지를 user내에 두었는데요, 패키징 어떠한지 의견 주시면 감사하겠습니다.
