### PR TITLE
[#11 ] 주문 접수 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,14 +34,18 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Apache Commons Lang
+    implementation 'org.apache.commons:commons-lang3:3.0'
+    
     // jdbc
     implementation 'org.springframework.data:spring-data-jdbc'
-    
-    implementation("com.google.guava:guava:31.1-jre") 
+
+    implementation("com.google.guava:guava:31.1-jre")
     implementation 'commons-validator:commons-validator:1.7'
 
     // p6spy

--- a/src/main/java/com/prgrms/bdbks/domain/item/entity/BeverageOption.java
+++ b/src/main/java/com/prgrms/bdbks/domain/item/entity/BeverageOption.java
@@ -44,7 +44,6 @@ public interface BeverageOption {
         private final String korName;
         private final String englishName;
 
-
         Milk(String korName, String englishName) {
             this.korName = korName;
             this.englishName = englishName;
@@ -66,8 +65,8 @@ public interface BeverageOption {
 
     @Getter
     enum Size {
-        TALL("Tall","355ml"),
-        GRANDE("Grande","473ml"),
+        TALL("Tall", "355ml"),
+        GRANDE("Grande", "473ml"),
         VENTI("Venti", "591ml");
 
         private final String englishName;
@@ -77,6 +76,20 @@ public interface BeverageOption {
             this.amount = amount;
             this.englishName = englishName;
         }
+    }
+
+    @Getter
+    enum CupType {
+        PERSONAL("개인컵"),
+        STORE("매장컵"),
+        DISPOSABLE("일회용컵");
+
+        private final String koreaName;
+
+        CupType(String koreaName) {
+            this.koreaName = koreaName;
+        }
+
     }
 
 }

--- a/src/main/java/com/prgrms/bdbks/domain/item/entity/DefaultOption.java
+++ b/src/main/java/com/prgrms/bdbks/domain/item/entity/DefaultOption.java
@@ -30,16 +30,16 @@ public class DefaultOption {
 	private Long id;
 
 	@Column(name = "espresso_shot_count", columnDefinition = "tinyint")
-	private int espressoShotCount = 0;
+	private Integer espressoShotCount;
 
 	@Column(name = "vanilla_syrup_count", columnDefinition = "tinyint")
-	private int vanillaSyrupCount = 0;
+	private Integer vanillaSyrupCount;
 
 	@Column(name = "classic_syrup_count", columnDefinition = "tinyint")
-	private int classicSyrupCount = 0;
+	private Integer classicSyrupCount;
 
 	@Column(name = "hazelnut_syrup_count", columnDefinition = "tinyint")
-	private int hazelnutSyrupCount = 0;
+	private Integer hazelnutSyrupCount;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "milk_type", length = 20)

--- a/src/main/java/com/prgrms/bdbks/domain/item/entity/Item.java
+++ b/src/main/java/com/prgrms/bdbks/domain/item/entity/Item.java
@@ -33,7 +33,7 @@ public class Item extends AbstractTimeColumn {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private String id;
+	private Long id;
 
 	@NotNull
 	@Column(name = "name", nullable = false, length = 50)

--- a/src/main/java/com/prgrms/bdbks/domain/order/entity/CustomOption.java
+++ b/src/main/java/com/prgrms/bdbks/domain/order/entity/CustomOption.java
@@ -1,4 +1,6 @@
-package com.prgrms.bdbks.domain.item.entity;
+package com.prgrms.bdbks.domain.order.entity;
+
+import static com.google.common.base.Preconditions.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -8,25 +10,25 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 
-import com.google.common.base.Preconditions;
-import com.prgrms.bdbks.domain.item.entity.BeverageOption.Coffee;
-import com.prgrms.bdbks.domain.item.entity.BeverageOption.Milk;
-import com.prgrms.bdbks.domain.item.entity.BeverageOption.MilkAmount;
+import com.prgrms.bdbks.common.domain.AbstractTimeColumn;
+import com.prgrms.bdbks.domain.item.entity.BeverageOption;
 
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "default_options")
+@Table(name = "custom_options")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DefaultOption {
+public class CustomOption extends AbstractTimeColumn {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "custom_option_id")
 	private Long id;
 
 	@Column(name = "espresso_shot_count", columnDefinition = "tinyint")
@@ -43,19 +45,33 @@ public class DefaultOption {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "milk_type", length = 20)
-	private Milk milkType = null;
+	private BeverageOption.Milk milkType = null;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "espresso_Type", length = 20)
-	private Coffee espressoType = null;
+	private BeverageOption.Coffee espressoType = null;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "milk_amount", length = 20)
-	private MilkAmount milkAmount = null;
+	private BeverageOption.MilkAmount milkAmount = null;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "cup_size", length = 10)
+	@NotNull
+	private BeverageOption.Size cupSize;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "cup_type", length = 10)
+	@NotNull
+	private BeverageOption.CupType cupType;
 
 	@Builder
-	protected DefaultOption(int espressoShotCount, int vanillaSyrupCount, int classicSyrupCount,
-		int hazelnutSyrupCount, Milk milkType, Coffee espressoType, MilkAmount milkAmount) {
+	protected CustomOption(Integer espressoShotCount, Integer vanillaSyrupCount, Integer classicSyrupCount,
+		Integer hazelnutSyrupCount, BeverageOption.Milk milkType, BeverageOption.Coffee espressoType,
+		BeverageOption.MilkAmount milkAmount, BeverageOption.Size cupSize, BeverageOption.CupType cupType) {
+
+		checkNotNull(cupType, "cupType 은 null 일 수 없습니다.");
+		checkNotNull(cupSize, "cupSize 는 null 일 수 없습니다.");
 
 		validateCount(hazelnutSyrupCount);
 		validateCount(espressoShotCount);
@@ -69,11 +85,12 @@ public class DefaultOption {
 		this.milkType = milkType;
 		this.espressoType = espressoType;
 		this.milkAmount = milkAmount;
+		this.cupSize = cupSize;
+		this.cupType = cupType;
 	}
 
 	private void validateCount(int count) {
-		Preconditions.checkArgument(count >= 0 && count <= 9, "Option 개수는 9보다 작은 양수여야합니다.");
-
+		checkArgument(count >= 0 && count <= 9, "Option 개수는 9보다 작은 양수여야합니다.");
 	}
 
 }

--- a/src/main/java/com/prgrms/bdbks/domain/order/entity/Order.java
+++ b/src/main/java/com/prgrms/bdbks/domain/order/entity/Order.java
@@ -1,0 +1,69 @@
+package com.prgrms.bdbks.domain.order.entity;
+
+import static com.google.common.base.Preconditions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import com.prgrms.bdbks.common.domain.AbstractTimeColumn;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "orders", indexes = @Index(name = "user_id_index", columnList = "user_id"))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends AbstractTimeColumn {
+
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(generator = "order_id_generator")
+	@GenericGenerator(name = "order_id_generator", strategy = "com.prgrms.bdbks.domain.order.repository.OrderIdGenerator")
+	private String id;
+
+	// 추후 객체 참조로 변경
+	@Column(name = "coupon_id")
+	private Long coupon;
+
+	@NotNull
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@NotNull
+	@Column(name = "store_id", nullable = false)
+	private String storeId;
+
+	@NotNull
+	@Column(name = "total_price", nullable = false)
+	private int totalPrice;
+
+	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<OrderItem> orderItems = new ArrayList<>();
+
+	@Builder
+	protected Order(Long coupon, Long userId, String storeId, int totalPrice) {
+		checkNotNull(userId, "userId 는 null 일 수 없습니다.");
+		checkNotNull(storeId, "storeId 는 null 일 수 없습니다.");
+		checkArgument(totalPrice >= 0, "totalPrice 는 0보다 작을 수 없습니다.");
+		this.coupon = coupon;
+		this.userId = userId;
+		this.storeId = storeId;
+		this.totalPrice = totalPrice;
+	}
+
+}

--- a/src/main/java/com/prgrms/bdbks/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/prgrms/bdbks/domain/order/entity/OrderItem.java
@@ -1,0 +1,65 @@
+package com.prgrms.bdbks.domain.order.entity;
+
+import static com.google.common.base.Preconditions.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+import com.prgrms.bdbks.domain.item.entity.Item;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private Order order;
+
+	@NotNull
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "item_id")
+	private Item item;
+
+	@NotNull
+	@OneToOne
+	@JoinColumn(name = "custom_option_id")
+	private CustomOption customOption;
+
+	@NotNull
+	@Column(name = "count", nullable = false)
+	private int count = 1;
+
+	@Builder
+	public OrderItem(Order order, Item item, CustomOption customOption, int count) {
+		checkArgument(count >= 1, "item 의 count 는 1개 이상이여야 합니다.");
+		checkNotNull(order, "order 는 null 일 수 없습니다.");
+		checkNotNull(item, "item 은 null 일 수 없습니다.");
+		checkNotNull(customOption, "customOption 은 null 일 수 없습니다.");
+
+		this.order = order;
+		this.item = item;
+		this.customOption = customOption;
+		this.count = count;
+	}
+
+}

--- a/src/main/java/com/prgrms/bdbks/domain/order/repository/OrderIdGenerator.java
+++ b/src/main/java/com/prgrms/bdbks/domain/order/repository/OrderIdGenerator.java
@@ -1,0 +1,23 @@
+package com.prgrms.bdbks.domain.order.repository;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+public class OrderIdGenerator implements IdentifierGenerator {
+
+	@Override
+	public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
+
+		String currentDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));
+		String randomId = RandomStringUtils.randomAlphabetic(4);
+
+		return currentDateTime + "HK" + randomId;
+	}
+
+}

--- a/src/test/java/com/prgrms/bdbks/domain/item/entity/DefaultOptionTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/item/entity/DefaultOptionTest.java
@@ -14,7 +14,7 @@ class DefaultOptionTest {
 	@ValueSource(ints = {-1, -2, 10, 11, 100, 999, -3, -555})
 	void constructor_create_count_over0_and_less_then0_fail(int count) {
 		// given & when & then
-		assertThrows(IllegalArgumentException.class, () -> DefaultOption.builder()
+		var i = assertThrows(IllegalArgumentException.class, () -> DefaultOption.builder()
 			.classicSyrupCount(count)
 			.espressoShotCount(count)
 			.vanillaSyrupCount(count)

--- a/src/test/java/com/prgrms/bdbks/domain/item/entity/DefaultOptionTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/item/entity/DefaultOptionTest.java
@@ -1,40 +1,25 @@
 package com.prgrms.bdbks.domain.item.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("DefaultOption 테스트")
 class DefaultOptionTest {
 
-    @DisplayName("생성 - Item() - 모든 shoutCount 를 지정하지 않으면 0으로 생성 성공한다.")
-    @Test
-    void constructor_create_success() {
-        // given & when
-        DefaultOption defaultOption = DefaultOption.builder().build();
-
-        //then
-        assertThat(defaultOption.getClassicSyrupCount()).isZero();
-        assertThat(defaultOption.getEspressoShotCount()).isZero();
-        assertThat(defaultOption.getVanillaSyrupCount()).isZero();
-        assertThat(defaultOption.getHazelnutSyrupCount()).isZero();
-    }
-
-    @DisplayName("생성 - Item() - 모든 shotCount가 0보다 작거나 9보다 크면 생성에 실패한다")
-    @ParameterizedTest
-    @ValueSource(ints = {-1, -2, 10, 11, 100, 999, -3, -555})
-    void constructor_create_count_over0_and_less_then0_fail(int count) {
-        // given & when & then
-        assertThrows(IllegalArgumentException.class, () -> DefaultOption.builder()
-            .classicSyrupCount(count)
-            .espressoShotCount(count)
-            .vanillaSyrupCount(count)
-            .hazelnutSyrupCount(count)
-            .build());
-    }
+	@DisplayName("생성 - Item() - 모든 shotCount가 0보다 작거나 9보다 크면 생성에 실패한다")
+	@ParameterizedTest
+	@ValueSource(ints = {-1, -2, 10, 11, 100, 999, -3, -555})
+	void constructor_create_count_over0_and_less_then0_fail(int count) {
+		// given & when & then
+		assertThrows(IllegalArgumentException.class, () -> DefaultOption.builder()
+			.classicSyrupCount(count)
+			.espressoShotCount(count)
+			.vanillaSyrupCount(count)
+			.hazelnutSyrupCount(count)
+			.build());
+	}
 
 }

--- a/src/test/java/com/prgrms/bdbks/domain/item/entity/ItemTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/item/entity/ItemTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.bdbks.domain.item.entity;
 
+import static com.prgrms.bdbks.domain.testutil.OrderObjectProvider.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +13,7 @@ class ItemTest {
 	@Test
 	void constructor_create_success() {
 		//given
-		ItemCategory itemCategory = createCategory();
+		ItemCategory itemCategory = createReserveEspressoCategory();
 
 		String name = "아이스 아메리카노";
 		String description = "진한 에스프레소에 시원한 정수물과 얼음을 더하여 스타벅스의 깔끔하고 강렬한 에스프레소를 가장 부드럽고 시원하게 즐길 수 있는 커피";
@@ -37,7 +38,7 @@ class ItemTest {
 	@Test
 	void constructor_create_name_empty_fail() {
 		//given
-		ItemCategory itemCategory = createCategory();
+		ItemCategory itemCategory = createReserveEspressoCategory();
 
 		String name = "";
 		String description = "진한 에스프레소에 시원한 정수물과 얼음을 더하여 스타벅스의 깔끔하고 강렬한 에스프레소를 가장 부드럽고 시원하게 즐길 수 있는 커피";
@@ -62,7 +63,7 @@ class ItemTest {
 	@Test
 	void constructor_create_with_name_length_over_30_fail() {
 		//given
-		ItemCategory itemCategory = createCategory();
+		ItemCategory itemCategory = createReserveEspressoCategory();
 
 		String name = "세상에서 가장 비싸고 맛있는 커피. 리저브 에스프레소. 엄청 긴 커피.12345678910 이 커피 가격은 999,999,9999,99999원";
 		String description = "진한 에스프레소에 시원한 정수물과 얼음을 더하여 스타벅스의 깔끔하고 강렬한 에스프레소를 가장 부드럽고 시원하게 즐길 수 있는 커피";
@@ -110,7 +111,7 @@ class ItemTest {
 	@Test
 	void constructor_create_englishName_empty_fail() {
 		//given
-		ItemCategory itemCategory = createCategory();
+		ItemCategory itemCategory = createReserveEspressoCategory();
 
 		String name = "아이스 아메리카노";
 		String description = "진한 에스프레소에 시원한 정수물과 얼음을 더하여 스타벅스의 깔끔하고 강렬한 에스프레소를 가장 부드럽고 시원하게 즐길 수 있는 커피";
@@ -135,7 +136,7 @@ class ItemTest {
 	@Test
 	void constructor_create_price_less_then0_fail() {
 		//given
-		ItemCategory itemCategory = createCategory();
+		ItemCategory itemCategory = createReserveEspressoCategory();
 
 		String name = "아이스 아메리카노";
 		String description = "진한 에스프레소에 시원한 정수물과 얼음을 더하여 스타벅스의 깔끔하고 강렬한 에스프레소를 가장 부드럽고 시원하게 즐길 수 있는 커피";
@@ -160,7 +161,7 @@ class ItemTest {
 	@Test
 	void constructor_create_description_empty_fail() {
 		//given
-		ItemCategory itemCategory = createCategory();
+		ItemCategory itemCategory = createReserveEspressoCategory();
 
 		String name = "아이스 아메리카노";
 		String description = null;
@@ -185,7 +186,7 @@ class ItemTest {
 	@Test
 	void constructor_create_image_empty_fail() {
 		//given
-		ItemCategory itemCategory = createCategory();
+		ItemCategory itemCategory = createReserveEspressoCategory();
 
 		String name = "아이스 아메리카노";
 		String description = "진한 에스프레소에 시원한 정수물과 얼음을 더하여 스타벅스의 깔끔하고 강렬한 에스프레소를 가장 부드럽고 시원하게 즐길 수 있는 커피";
@@ -205,18 +206,6 @@ class ItemTest {
 				.description(description)
 				.build();
 		});
-	}
-
-	private static ItemCategory createCategory() {
-		ItemType beverage = ItemType.BEVERAGE;
-		String itemCategoryName = "리저브 에스프레소";
-		String itemCategoryEnglishName = "Reserve Espresso";
-
-		return ItemCategory.builder()
-			.name(itemCategoryName)
-			.englishName(itemCategoryEnglishName)
-			.itemType(beverage)
-			.build();
 	}
 
 }

--- a/src/test/java/com/prgrms/bdbks/domain/order/entity/CustomOptionTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/order/entity/CustomOptionTest.java
@@ -1,0 +1,104 @@
+package com.prgrms.bdbks.domain.order.entity;
+
+import static com.prgrms.bdbks.domain.item.entity.BeverageOption.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("CustomOption 테스트")
+class CustomOptionTest {
+
+	private final Integer espressoShotCount = 2;
+
+	private final Integer vanillaSyrupCount = 1;
+
+	private final Integer classicSyrupCount = 3;
+
+	private final Integer hazelnutSyrupCount = 4;
+
+	private final Milk milkType = Milk.OAT;
+
+	private final Coffee espressoType = Coffee.DECAFFEINATED;
+
+	private final MilkAmount milkAmount = MilkAmount.MEDIUM;
+
+	private final Size cupSize = Size.VENTI;
+
+	private final CupType cupType = CupType.DISPOSABLE;
+
+	@DisplayName("생성 - CustomOption() - 생성에 성공한다.")
+	@Test
+	void builder_create_success() {
+		// given & when & then
+		assertDoesNotThrow(() -> {
+			CustomOption.builder()
+				.espressoType(espressoType)
+				.espressoShotCount(espressoShotCount)
+				.vanillaSyrupCount(vanillaSyrupCount)
+				.hazelnutSyrupCount(hazelnutSyrupCount)
+				.classicSyrupCount(classicSyrupCount)
+				.milkType(milkType)
+				.milkAmount(milkAmount)
+				.cupType(cupType)
+				.cupSize(cupSize)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - CustomOption() - cupType가 null 이면 생성에 실패한다.")
+	@Test
+	void builder_create_cupType_null_fail() {
+		//given & when & then
+		assertThrows(NullPointerException.class, () -> {
+			CustomOption.builder()
+				.espressoType(espressoType)
+				.espressoShotCount(espressoShotCount)
+				.vanillaSyrupCount(vanillaSyrupCount)
+				.hazelnutSyrupCount(hazelnutSyrupCount)
+				.classicSyrupCount(classicSyrupCount)
+				.milkType(milkType)
+				.milkAmount(milkAmount)
+				.cupType(null)
+				.cupSize(cupSize)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - CustomOption() - cupSize가 null 이면 생성에 실패한다.")
+	@Test
+	void builder_create_cupSize_null_fail() {
+		//given & when & then
+		assertThrows(NullPointerException.class, () -> {
+			CustomOption.builder()
+				.espressoType(espressoType)
+				.espressoShotCount(espressoShotCount)
+				.vanillaSyrupCount(vanillaSyrupCount)
+				.hazelnutSyrupCount(hazelnutSyrupCount)
+				.classicSyrupCount(classicSyrupCount)
+				.milkType(milkType)
+				.milkAmount(milkAmount)
+				.cupType(cupType)
+				.cupSize(null)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - CustomOption() - 모든 optin의 개수는 0보다 작거나 9보다 크면 생성에 실패한다")
+	@ParameterizedTest
+	@ValueSource(ints = {-1, -2, 10, 11, 100, 999, -3, -555})
+	void constructor_create_count_over0_and_less_then0_fail(int count) {
+		// given & when & then
+		assertThrows(IllegalArgumentException.class, () -> CustomOption.builder()
+			.classicSyrupCount(count)
+			.espressoShotCount(count)
+			.vanillaSyrupCount(count)
+			.hazelnutSyrupCount(count)
+			.cupType(cupType)
+			.cupSize(cupSize)
+			.build());
+	}
+
+}

--- a/src/test/java/com/prgrms/bdbks/domain/order/entity/OrderItemTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/order/entity/OrderItemTest.java
@@ -1,0 +1,95 @@
+package com.prgrms.bdbks.domain.order.entity;
+
+import static com.prgrms.bdbks.domain.testutil.OrderObjectProvider.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.prgrms.bdbks.domain.item.entity.Item;
+
+@DisplayName("OrderItem 테스트")
+class OrderItemTest {
+
+	private final int count = 3;
+
+	private final Item item = createIcedAmericano();
+
+	private final Order order = createOrder();
+
+	private final CustomOption customOption = createCustomOption();
+
+	@DisplayName("생성 - OrderItem() - 생성에 성공한다.")
+	@Test
+	void builder_create_success() {
+		// given & when & then
+		assertDoesNotThrow(() -> {
+			OrderItem.builder()
+				.order(order)
+				.item(item)
+				.customOption(customOption)
+				.count(count)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - OrderItem() - count가 0개 이하면 생성에 실패한다.")
+	@ParameterizedTest
+	@ValueSource(ints = {-1, -2, -3, -4, -99, 0})
+	void builder_create_count_less_then0_fail(int lessThen0Count) {
+		//given & when & then
+		assertThrows(IllegalArgumentException.class, () -> {
+			OrderItem.builder()
+				.order(order)
+				.item(item)
+				.customOption(customOption)
+				.count(lessThen0Count)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - OrderItem() - order가 null 이면 생성에 실패한다.")
+	@Test
+	void builder_create_order_null__fail() {
+		//given & when & then
+		assertThrows(NullPointerException.class, () -> {
+			OrderItem.builder()
+				.order(null)
+				.item(item)
+				.customOption(customOption)
+				.count(count)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - OrderItem() - item 이 null 이면 생성에 실패한다.")
+	@Test
+	void builder_create_item_null__fail() {
+		//given & when & then
+		assertThrows(NullPointerException.class, () -> {
+			OrderItem.builder()
+				.order(order)
+				.item(null)
+				.customOption(customOption)
+				.count(count)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - OrderItem() - customOption 이 null 이면 생성에 실패한다.")
+	@Test
+	void builder_create_custom_option_null__fail() {
+		//given & when & then
+		assertThrows(NullPointerException.class, () -> {
+			OrderItem.builder()
+				.order(order)
+				.item(item)
+				.customOption(null)
+				.count(count)
+				.build();
+		});
+	}
+
+}

--- a/src/test/java/com/prgrms/bdbks/domain/order/entity/OrderTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/order/entity/OrderTest.java
@@ -1,0 +1,81 @@
+package com.prgrms.bdbks.domain.order.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Order 테스트")
+class OrderTest {
+
+	private final Long couponId = 2347634L;
+	private final Long userId = 439854L;
+	private final String storeId = "20304";
+	private final int totalPrice = 32500;
+
+	@DisplayName("생성 - Order() - 생성에 성공한다.")
+	@Test
+	void builder_create_success() {
+		//given
+		//when & then
+		assertDoesNotThrow(() -> {
+			Order.builder().coupon(couponId)
+				.userId(userId)
+				.storeId(storeId)
+				.totalPrice(totalPrice)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - order() - userId가 null 이면 생성에 실패한다.")
+	@Test
+	void builder_create_userId_null_fail() {
+		//given
+		Long nullUserId = null;
+
+		//when & then
+		assertThrows(NullPointerException.class, () -> {
+			Order.builder()
+				.userId(nullUserId)
+				.coupon(couponId)
+				.storeId(storeId)
+				.totalPrice(totalPrice)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - order() - storeId가 null 이면 생성에 실패한다.")
+	@Test
+	void builder_create_storId_null_fail() {
+		//given
+		String nullStoreId = null;
+
+		//when & then
+		assertThrows(NullPointerException.class, () -> {
+			Order.builder()
+				.userId(userId)
+				.coupon(couponId)
+				.storeId(nullStoreId)
+				.totalPrice(totalPrice)
+				.build();
+		});
+	}
+
+	@DisplayName("생성 - order() - totalPrice 가 0 보다 작으면 생성에 실패한다.")
+	@Test
+	void builder_create_totalPrice_less_then0_fail() {
+		//given
+		int lessThan0TotalPrice = -1;
+
+		//when & then
+		assertThrows(IllegalArgumentException.class, () -> {
+			Order.builder()
+				.userId(userId)
+				.coupon(couponId)
+				.storeId(storeId)
+				.totalPrice(lessThan0TotalPrice)
+				.build();
+		});
+	}
+
+}

--- a/src/test/java/com/prgrms/bdbks/domain/order/repository/OrderIdGeneratorTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/order/repository/OrderIdGeneratorTest.java
@@ -1,0 +1,47 @@
+package com.prgrms.bdbks.domain.order.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class OrderIdGeneratorTest {
+
+	private final OrderIdGenerator orderIdGenerator = new OrderIdGenerator();
+
+	@DisplayName("생성 - IdString () - 날짜 + HK + RandomCharacter 형식으로 생성에 성공한다.")
+	@Test
+	void generate_id_create_success() {
+		//given
+		LocalDateTime now = LocalDateTime.of(2023, 1, 16, 20, 50, 10, 12345);
+
+		SharedSessionContractImplementor mockSession = mock(SharedSessionContractImplementor.class);
+
+		Object mockObject = mock(Object.class);
+
+		try (MockedStatic<LocalDateTime> mockLocalDateTime = mockStatic(LocalDateTime.class)) {
+			given(LocalDateTime.now()).willReturn(now);
+			//when
+			String generateOrderId = orderIdGenerator.generate(mockSession, mockObject).toString();
+
+			String currentDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));
+
+			//then
+			assertTrue(generateOrderId.contains(currentDateTime));
+			assertTrue(generateOrderId.contains("HK"));
+			log.info(generateOrderId);
+			log.info(currentDateTime);
+			mockLocalDateTime.verify(LocalDateTime::now, atLeast(2));
+		}
+
+	}
+}

--- a/src/test/java/com/prgrms/bdbks/domain/order/repository/OrderIdGeneratorTest.java
+++ b/src/test/java/com/prgrms/bdbks/domain/order/repository/OrderIdGeneratorTest.java
@@ -41,6 +41,7 @@ class OrderIdGeneratorTest {
 			log.info(generateOrderId);
 			log.info(currentDateTime);
 			mockLocalDateTime.verify(LocalDateTime::now, atLeast(2));
+			assertEquals(generateOrderId.length(), currentDateTime.length() + 2 + 4);
 		}
 
 	}

--- a/src/test/java/com/prgrms/bdbks/domain/testutil/OrderObjectProvider.java
+++ b/src/test/java/com/prgrms/bdbks/domain/testutil/OrderObjectProvider.java
@@ -1,0 +1,104 @@
+package com.prgrms.bdbks.domain.testutil;
+
+import com.prgrms.bdbks.domain.item.entity.BeverageOption;
+import com.prgrms.bdbks.domain.item.entity.Item;
+import com.prgrms.bdbks.domain.item.entity.ItemCategory;
+import com.prgrms.bdbks.domain.item.entity.ItemType;
+import com.prgrms.bdbks.domain.order.entity.CustomOption;
+import com.prgrms.bdbks.domain.order.entity.Order;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderObjectProvider {
+
+	public static ItemCategory createReserveEspressoCategory() {
+		ItemType beverage = ItemType.BEVERAGE;
+		String itemCategoryName = "리저브 에스프레소";
+		String itemCategoryEnglishName = "Reserve Espresso";
+
+		return ItemCategory.builder()
+			.name(itemCategoryName)
+			.englishName(itemCategoryEnglishName)
+			.itemType(beverage)
+			.build();
+	}
+
+	public static Item createIcedAmericano() {
+		ItemCategory itemCategory = createReserveEspressoCategory();
+		String name = "아이스 아메리카노";
+		String description = "진한 에스프레소에 시원한 정수물과 얼음을 더하여 스타벅스의 깔끔하고 강렬한 에스프레소를 가장 부드럽고 시원하게 즐길 수 있는 커피";
+		String englishName = "Iced Caffe Americano";
+		int price = 4500;
+
+		String image = "https://hkbks.com/api/image.jpg";
+
+		return Item.builder()
+			.description(description)
+			.name(name)
+			.category(itemCategory)
+			.englishName(englishName)
+			.price(price)
+			.image(image)
+			.build();
+	}
+
+	public static Item createItem(String name, ItemCategory category, String englishName, int price, String image,
+		String description) {
+
+		return Item.builder()
+			.name(name)
+			.category(category)
+			.englishName(englishName)
+			.price(price)
+			.image(image)
+			.build();
+	}
+
+	public static Order createOrder(Long coupon, Long userId, String storeId, int totalPrice) {
+
+		return Order.builder()
+			.coupon(coupon)
+			.userId(userId)
+			.storeId(storeId)
+			.totalPrice(totalPrice)
+			.build();
+	}
+
+	public static Order createOrder() {
+		return Order.builder()
+			.coupon(null)
+			.userId(1L)
+			.storeId("123456789")
+			.totalPrice(45000)
+			.build();
+	}
+
+	public static CustomOption createCustomOption(Integer espressoShotCount, Integer vanillaSyrupCount,
+		Integer classicSyrupCount, Integer hazelnutSyrupCount, BeverageOption.Milk milkType,
+		BeverageOption.Coffee espressoType,
+		BeverageOption.MilkAmount milkAmount, BeverageOption.Size cupSize, BeverageOption.CupType cupType) {
+
+		return CustomOption.builder()
+			.espressoType(espressoType)
+			.espressoShotCount(espressoShotCount)
+			.vanillaSyrupCount(vanillaSyrupCount)
+			.classicSyrupCount(classicSyrupCount)
+			.hazelnutSyrupCount(hazelnutSyrupCount)
+			.milkAmount(milkAmount)
+			.milkType(milkType)
+			.cupSize(cupSize)
+			.cupType(cupType)
+			.build();
+
+	}
+
+	public static CustomOption createCustomOption() {
+		return createCustomOption(1, 0, 0, 0,
+			BeverageOption.Milk.OAT, BeverageOption.Coffee.DECAFFEINATED,
+			BeverageOption.MilkAmount.MEDIUM, BeverageOption.Size.TALL,
+			BeverageOption.CupType.STORE);
+	}
+
+}

--- a/src/test/java/com/prgrms/bdbks/sample/SampleRepositoryTest.java
+++ b/src/test/java/com/prgrms/bdbks/sample/SampleRepositoryTest.java
@@ -1,8 +1,11 @@
 package com.prgrms.bdbks.sample;
 
-import com.prgrms.bdbks.CustomDataJpaTest;
+import javax.sql.DataSource;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.prgrms.bdbks.CustomDataJpaTest;
 
 @CustomDataJpaTest
 class SampleRepositoryTest {
@@ -10,9 +13,14 @@ class SampleRepositoryTest {
     @Autowired
     private SampleRepository sampleRepository;
 
+    @Autowired
+    private DataSource dataSource;
+
     @Test
     void findByIdTest() {
         sampleRepository.findById(50L);
+
+        System.out.println(dataSource);
     }
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,16 +1,15 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:bdbks;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;
+    url: jdbc:h2:mem:bdbks_test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;
     username: sa
     password:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: false
     properties:
       hibernate.format_sql: false
       dialect: org.hibernate.dialect.H2Dialect
     database: h2
-


### PR DESCRIPTION
### 🍀 목적
- ex) 주문 관련 도메인 엔티티 구현

### 🌹 추가사항(있다면 적고 없다면 적지 않는다.)
- 주문 Id를 커스텀 생성하게 위해 OrderIdGenerator 구현 

### ☕ 변경사항(있다면 적고 없다면 적지 않는다.)
- DefaultOption Entity syrup count의 자료형을 int -> Integer로 변경하고 default value를 null로 변경.
