### PR TITLE
[#72] JwtConfigure 빈 등록 실패 해결

### DIFF
--- a/src/main/java/com/prgrms/bdbks/BlackDogBucksApplication.java
+++ b/src/main/java/com/prgrms/bdbks/BlackDogBucksApplication.java
@@ -2,12 +2,14 @@ package com.prgrms.bdbks;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan(basePackages = {"com.prgrms.bdbks.config.jwt"})
 @SpringBootApplication
 public class BlackDogBucksApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(BlackDogBucksApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(BlackDogBucksApplication.class, args);
+	}
 
 }

--- a/src/main/java/com/prgrms/bdbks/config/jwt/JwtConfigure.java
+++ b/src/main/java/com/prgrms/bdbks/config/jwt/JwtConfigure.java
@@ -1,15 +1,15 @@
-package com.prgrms.bdbks.domain.user.jwt;
+package com.prgrms.bdbks.config.jwt;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
-import org.springframework.context.annotation.Configuration;
 
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-@Configuration
 @ConfigurationProperties(prefix = "jwt")
 @ConstructorBinding
-@RequiredArgsConstructor
+@Getter
+@AllArgsConstructor
 public class JwtConfigure {
 
 	private final String authoritiesKey;
@@ -20,23 +20,8 @@ public class JwtConfigure {
 
 	private final long tokenValidityInSeconds;
 
-	public String getAuthoritiesKey() {
-		return authoritiesKey;
-	}
-
-	public String getHeader() {
-		return header;
-	}
-
-	public String getSecret() {
-		return secret;
-	}
-
 	public long getTokenValidityInSeconds(long seconds) {
 		return tokenValidityInSeconds * seconds;
 	}
 
-	public long getTokenValidityInSeconds() {
-		return tokenValidityInSeconds * 1000;
-	}
 }

--- a/src/main/java/com/prgrms/bdbks/domain/user/jwt/TokenProvider.java
+++ b/src/main/java/com/prgrms/bdbks/domain/user/jwt/TokenProvider.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import com.prgrms.bdbks.common.exception.AuthorityNotFoundException;
 import com.prgrms.bdbks.common.exception.JwtValidateException;
+import com.prgrms.bdbks.config.jwt.JwtConfigure;
 import com.prgrms.bdbks.domain.user.entity.User;
 
 import io.jsonwebtoken.Claims;


### PR DESCRIPTION
[#72 ] [User] JwtConfigure 빈 등록 실패

### 🍀 목적
- JwtConfigure를 수정하여 애플리케이션 컨텍스트가 생성되도록 한다.


### ☕ 변경사항
- JwtConfigure 빈 등록 해제
- JwtConfigure Getter 어노테이션 생성
- JwtConfigure 패키지구조 변경
- `BlackDogBucksApplication` 클래스에 `@ConfigurationPropertiesScan` 추가